### PR TITLE
Fix form row CSS rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,10 @@
             margin: 0;
             padding: 0;
             box-sizing: border-box;
-            .form-row {
-                grid-template-columns: 1fr;
-            }
+        }
+
+        .form-row {
+            grid-template-columns: 1fr;
         }
 
         body {


### PR DESCRIPTION
## Summary
- move `.form-row` rule out of universal selector for cleaner CSS

## Testing
- `grep -n form-row -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6850d0e1c47c83209a718d18041cb2f9