### PR TITLE
Add Supabase example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ Esta landing page ofrece un formulario de registro para la beta privada de **Uni
 ## Ejecutar el formulario en local
 
 No se necesitan dependencias adicionales. Abre `index.html` directamente en tu navegador web favorito y comprueba que el formulario se visualiza correctamente.
+
+## Probar conexión a Supabase con Node.js
+
+Si deseas verificar que puedes leer e insertar en la tabla `contact_form` utilizando el SDK de Supabase para JavaScript, sigue estos pasos:
+
+1. Instala la dependencia:
+   ```bash
+   npm install @supabase/supabase-js
+   ```
+2. Crea un archivo `.env` con tus credenciales:
+   ```
+   SUPABASE_URL=tu_url
+   SUPABASE_KEY=tu_clave_publica
+   ```
+3. Ejecuta el script `supabase_example.js`:
+   ```bash
+   node supabase_example.js
+   ```
+   Este script mostrará las filas existentes e insertará una fila de prueba para validar la conexión.

--- a/supabase_example.js
+++ b/supabase_example.js
@@ -1,0 +1,33 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Use environment variables to avoid hardcoding credentials
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function readTable() {
+  const { data, error } = await supabase.from('contact_form').select('*');
+  if (error) {
+    throw error;
+  }
+  console.log('Existing rows:', data);
+}
+
+async function insertRow(row) {
+  const { data, error } = await supabase.from('contact_form').insert([row]).select();
+  if (error) {
+    throw error;
+  }
+  console.log('Inserted row:', data);
+}
+
+async function main() {
+  await readTable();
+  await insertRow({ first_name: 'Test', last_name: 'User', email: 'test@example.com' });
+}
+
+main().catch(err => {
+  console.error('Supabase error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- provide Node.js script to read/insert data with Supabase
- document how to run the example in README

## Testing
- `node --check supabase_example.js`

------
https://chatgpt.com/codex/tasks/task_e_6852fe75116c8320bb30c63993d901c4